### PR TITLE
feat: configure Vite proxy and Nginx for WebSocket traffic

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,11 +10,22 @@ server {
 
     # Proxy API requests to the backend
     location /api/ {
-        proxy_pass http://backend:8080/;
+        proxy_pass http://backend:8081/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+    }
+
+    # Proxy WebSocket connections
+    location /ws {
+        proxy_pass http://backend:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 86400s;
     }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,9 +15,13 @@ export default defineConfig({
     host: true,
     proxy: {
       '/api': {
-        target: 'http://backend:8080',
+        target: 'http://backend:8081',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
+      },
+      '/ws': {
+        target: 'http://backend:8081',
+        ws: true
       }
     }
   }


### PR DESCRIPTION
## Summary

Configures both the Vite dev server proxy and the production Nginx config to support WebSocket connections alongside the existing REST API proxy.

## Changes

- **`frontend/vite.config.ts`**: Add `/ws` proxy entry with `ws: true` for WebSocket support in the Vite dev server; fix pre-existing wrong port `8080` → `8081` for the `/api` proxy target
- **`frontend/nginx.conf`**: Add `location /ws` block with full WebSocket upgrade headers (`Upgrade`, `Connection`) and `proxy_read_timeout 86400s` to keep long-lived connections alive; fix pre-existing wrong port `8080` → `8081` for the `/api/` proxy_pass target

## Testing

- Start the stack with `make dev` and verify `/api` requests reach the backend
- Connect a WebSocket client to `/ws` and confirm the connection is proxied correctly in both dev (Vite) and production (Nginx)- Connect a WebSocket client to `/ws` and confirm the cot